### PR TITLE
FIX(trending): actualizar sección de tendencias para incluir películas

### DIFF
--- a/pixela-frontend/src/features/trending/components/TrendingSection.tsx
+++ b/pixela-frontend/src/features/trending/components/TrendingSection.tsx
@@ -2,23 +2,28 @@
 
 import { useEffect } from 'react';
 import { useTrendingStore } from '@/features/trending/store';
-import { TrendingSerie } from '@/features/trending/type';
+import { TrendingSerie, TrendingMovie } from '@/features/trending/type';
 import { TrendingHeader } from '@/features/trending/components/TrendingHeader';
 
 interface TrendingSectionProps {
   series: TrendingSerie[];
+  movies: TrendingMovie[];
 }
 
-export const TrendingSection = ({ series }: TrendingSectionProps) => {
-  // Obtenemos la función para actualizar el estado
+export const TrendingSection = ({ series, movies }: TrendingSectionProps) => {
+  // Obtenemos las funciones para actualizar el estado
   const setSeries = useTrendingStore((state) => state.setSeries);
+  const setMovies = useTrendingStore((state) => state.setMovies);
 
   // Inicializamos el store con los datos recibidos
   useEffect(() => {
     if (series && series.length > 0) {
       setSeries(series);
     }
-  }, [series, setSeries]);
+    if (movies && movies.length > 0) {
+      setMovies(movies);
+    }
+  }, [series, movies, setSeries, setMovies]);
 
   // Renderizamos el header (que internamente obtiene los datos del store)
   return <TrendingHeader />;


### PR DESCRIPTION
- Se modificó la interfaz `TrendingSectionProps` para aceptar un nuevo parámetro `movies`.
- Se añadieron funciones para actualizar el estado de las películas en la tienda.
- Se implementó la lógica para inicializar el estado con las películas recibidas en el efecto `useEffect`.