### PR TITLE
docs: traducción de comentarios de documentación al inglés y mejora visual en botón de favoritos

### DIFF
--- a/pixela-backend/app/Http/Controllers/Api/AuthController.php
+++ b/pixela-backend/app/Http/Controllers/Api/AuthController.php
@@ -76,17 +76,17 @@ class AuthController extends Controller
      */
     public function logout(Request $request): JsonResponse
     {
-        // Revoca todos los tokens de API
+        // Revokes all API tokens
         if ($user = $request->user()) {
             $user->tokens()->delete();
         }
 
-        // Invalida la sesión actual
+        // Invalidates the current session
         Auth::guard('web')->logout();
         $request->session()->invalidate();
         $request->session()->regenerateToken();
 
-        // Limpia la cookie de sesión
+        // Clears the session cookie
         Cookie::queue(Cookie::forget('pixela_session'));
 
         return response()

--- a/pixela-backend/app/Http/Controllers/Api/FavoriteController.php
+++ b/pixela-backend/app/Http/Controllers/Api/FavoriteController.php
@@ -15,8 +15,6 @@ use Illuminate\Http\JsonResponse;
  *     description="User favorites list management operations"
  * )
  */
-
-// Los schemas se han movido a app/OpenApi/Schemas/Favorite.php
 class FavoriteController extends Controller
 {
     /**
@@ -139,7 +137,7 @@ class FavoriteController extends Controller
 
     /**
      * @OA\Get(
-     *     path="/api/favorites",
+     *     path="/api/favorites/details",
      *     summary="List favorites",
      *     description="Get user's complete favorites list with details for each item",
      *     operationId="listFavorites",

--- a/pixela-backend/app/Http/Controllers/Api/ReviewController.php
+++ b/pixela-backend/app/Http/Controllers/Api/ReviewController.php
@@ -12,7 +12,7 @@ use GuzzleHttp\Client;
 /**
  * @OA\Tag(
  *     name="Reviews",
- *     description="Operaciones relacionadas con reseñas de películas y series"
+ *     description="Operations related to movie and series reviews"
  * )
  */
 
@@ -21,8 +21,8 @@ class ReviewController extends Controller
     /**
      * @OA\Post(
      *     path="/api/reviews",
-     *     summary="Añadir una nueva reseña",
-     *     description="Crea una nueva reseña para una película o serie",
+     *     summary="Add a new review",
+     *     description="Creates a new review for a movie or series",
      *     operationId="addReview",
      *     tags={"Reviews"},
      *     security={{ "sanctum": {} }},
@@ -32,17 +32,17 @@ class ReviewController extends Controller
      *     ),
      *     @OA\Response(
      *         response=201,
-     *         description="Reseña creada exitosamente",
+     *         description="Review created successfully",
      *         @OA\JsonContent(ref="#/components/schemas/ReviewResponse")
      *     ),
      *     @OA\Response(
      *         response=400,
-     *         description="La reseña ya existe o datos inválidos",
+     *         description="Review already exists or invalid data",
      *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
      *     ),
      *     @OA\Response(
      *         response=401,
-     *         description="No autenticado",
+     *         description="Unauthorized",
      *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
      *     )
      * )
@@ -83,8 +83,8 @@ class ReviewController extends Controller
     /**
      * @OA\Put(
      *     path="/api/reviews/{review}",
-     *     summary="Actualizar una reseña",
-     *     description="Actualiza una reseña existente",
+     *     summary="Update a review",
+     *     description="Updates an existing review",
      *     operationId="updateReview",
      *     tags={"Reviews"},
      *     security={{ "sanctum": {} }},
@@ -92,7 +92,7 @@ class ReviewController extends Controller
      *         name="review",
      *         in="path",
      *         required=true,
-     *         description="ID de la reseña",
+     *         description="Review ID",
      *         @OA\Schema(type="integer")
      *     ),
      *     @OA\RequestBody(
@@ -101,17 +101,17 @@ class ReviewController extends Controller
      *     ),
      *     @OA\Response(
      *         response=200,
-     *         description="Reseña actualizada exitosamente",
+     *         description="Review updated successfully",
      *         @OA\JsonContent(ref="#/components/schemas/ReviewResponse")
      *     ),
      *     @OA\Response(
      *         response=403,
-     *         description="No autorizado para actualizar esta reseña",
+     *         description="Unauthorized to update this review",
      *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
      *     ),
      *     @OA\Response(
      *         response=401,
-     *         description="No autenticado",
+     *         description="Unauthorized",
      *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
      *     )
      * )
@@ -145,19 +145,19 @@ class ReviewController extends Controller
     /**
      * @OA\Get(
      *     path="/api/reviews",
-     *     summary="Listar reseñas del usuario",
-     *     description="Obtiene todas las reseñas del usuario autenticado",
+     *     summary="List user reviews",
+     *     description="Gets all the reviews of the authenticated user",
      *     operationId="listReviews",
      *     tags={"Reviews"},
      *     security={{ "sanctum": {} }},
      *     @OA\Response(
      *         response=200,
-     *         description="Lista de reseñas recuperada exitosamente",
+     *         description="Reviews list retrieved successfully",
      *         @OA\JsonContent(ref="#/components/schemas/ReviewListResponse")
      *     ),
      *     @OA\Response(
      *         response=401,
-     *         description="No autenticado",
+     *         description="Unauthorized",
      *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
      *     )
      * )
@@ -223,8 +223,8 @@ class ReviewController extends Controller
     /**
      * @OA\Delete(
      *     path="/api/reviews/{review}",
-     *     summary="Eliminar una reseña",
-     *     description="Elimina una reseña específica",
+     *     summary="Delete a review",
+     *     description="Deletes a specific review",
      *     operationId="deleteReview",
      *     tags={"Reviews"},
      *     security={{ "sanctum": {} }},
@@ -232,12 +232,12 @@ class ReviewController extends Controller
      *         name="review",
      *         in="path",
      *         required=true,
-     *         description="ID de la reseña",
+     *         description="Review ID",
      *         @OA\Schema(type="integer")
      *     ),
      *     @OA\Response(
      *         response=200,
-     *         description="Reseña eliminada exitosamente",
+     *         description="Review deleted successfully",
      *         @OA\JsonContent(
      *             @OA\Property(property="success", type="boolean", example=true),
      *             @OA\Property(property="message", type="string", example="Review deleted successfully")
@@ -245,12 +245,12 @@ class ReviewController extends Controller
      *     ),
      *     @OA\Response(
      *         response=403,
-     *         description="No autorizado para eliminar esta reseña",
+     *         description="Unauthorized to delete this review",
      *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
      *     ),
      *     @OA\Response(
      *         response=401,
-     *         description="No autenticado",
+     *         description="Unauthorized",
      *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
      *     )
      * )

--- a/pixela-backend/app/Http/Controllers/Api/TmdbController.php
+++ b/pixela-backend/app/Http/Controllers/Api/TmdbController.php
@@ -12,7 +12,7 @@ use Exception;
 /**
  * @OA\Tag(
  *     name="TMDB",
- *     description="Operaciones generales de TMDB - categorías y contenido trending"
+ *     description="General TMDB operations - categories and trending content"
  * )
  */
 class TmdbController extends Controller
@@ -38,18 +38,18 @@ class TmdbController extends Controller
     /**
      * @OA\Get(
      *     path="/api/tmdb/categories",
-     *     summary="Obtener todas las categorías/géneros",
-     *     description="Retorna la lista completa de categorías/géneros disponibles en TMDB",
+     *     summary="Get all categories/genres",
+     *     description="Returns the complete list of categories/genres available in TMDB",
      *     operationId="getAllCategories",
      *     tags={"TMDB"},
      *     @OA\Response(
      *         response=200,
-     *         description="Lista de categorías recuperada exitosamente",
+     *         description="Categories list retrieved successfully",
      *         @OA\JsonContent(ref="#/components/schemas/CategoryResponse")
      *     ),
      *     @OA\Response(
      *         response=500,
-     *         description="Error del servidor",
+     *         description="Server error",
      *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
      *     )
      * )
@@ -75,20 +75,20 @@ class TmdbController extends Controller
     /**
      * @OA\Get(
      *     path="/api/tmdb/trending",
-     *     summary="Obtener contenido trending",
-     *     description="Retorna una lista paginada de películas y series que son tendencia",
+     *     summary="Get trending content",
+     *     description="Returns a paginated list of movies and series that are trending",
      *     operationId="getAllTrending",
      *     tags={"TMDB"},
      *     @OA\Parameter(
      *         name="page",
      *         in="query",
      *         required=false,
-     *         description="Número de página (por defecto: 1)",
+     *         description="Page number (default: 1)",
      *         @OA\Schema(type="integer", default=1)
      *     ),
      *     @OA\Response(
      *         response=200,
-     *         description="Lista de contenido trending recuperada exitosamente",
+     *         description="Trending content list retrieved successfully",
      *         @OA\JsonContent(
      *             allOf={
      *                 @OA\Schema(ref="#/components/schemas/PaginatedResponse"),
@@ -113,7 +113,7 @@ class TmdbController extends Controller
      *     ),
      *     @OA\Response(
      *         response=500,
-     *         description="Error del servidor",
+     *         description="Server error",
      *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
      *     )
      * )

--- a/pixela-backend/app/Models/User.php
+++ b/pixela-backend/app/Models/User.php
@@ -2,8 +2,6 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
-
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;

--- a/pixela-backend/app/Transformers/SeriesTransformer.php
+++ b/pixela-backend/app/Transformers/SeriesTransformer.php
@@ -5,7 +5,7 @@ namespace App\Transformers;
 class SeriesTransformer
 {
     /**
-     * Transforma los datos de una única serie.
+     * Transforms all the data of a series.
      *
      * @param array $series
      * @return array
@@ -25,7 +25,7 @@ class SeriesTransformer
     }
 
     /**
-     * Transforma un conjunto de series.
+     * Transforms a collection of series.
      *
      * @param array $series
      * @return array

--- a/pixela-backend/app/Transformers/TmdbTransformer.php
+++ b/pixela-backend/app/Transformers/TmdbTransformer.php
@@ -4,13 +4,12 @@ namespace App\Transformers;
 
 class TmdbTransformer
 {
-    public static function transformCollection(array $items): array
-    {
-        return array_map(function ($item) {
-            return self::transform($item);
-        }, $items);
-    }
-
+    /**
+     * Transforms a single item.
+     *
+     * @param array $item
+     * @return array
+     */
     public static function transform(array $item): array
     {
         return [
@@ -24,5 +23,18 @@ class TmdbTransformer
             'vote_average' => $item['vote_average'] ?? null,
             'release_date' => $item['release_date'] ?? ($item['first_air_date'] ?? null),
         ];
+    }
+
+    /**
+     * Transforms a collection of items.
+     *
+     * @param array $items
+     * @return array
+     */
+    public static function transformCollection(array $items): array
+    {
+        return array_map(function ($item) {
+            return self::transform($item);
+        }, $items);
     }
 } 

--- a/pixela-backend/routes/api.php
+++ b/pixela-backend/routes/api.php
@@ -22,7 +22,6 @@ Route::middleware('auth:sanctum')->group(function() {
     Route::delete('/users/{user}', [UserController::class, 'delete']);
 
     // Favorites routes
-    Route::get('/favorites', [FavoriteController::class, 'list']);
     Route::post('/favorites', [FavoriteController::class, 'add']);
     Route::delete('/favorites/{favorite}', [FavoriteController::class, 'delete']);
     Route::get('/favorites/details', [FavoriteController::class, 'listWithDetails']);

--- a/pixela-backend/storage/api-docs/api-docs.json
+++ b/pixela-backend/storage/api-docs/api-docs.json
@@ -118,57 +118,6 @@
             }
         },
         "/api/favorites": {
-            "get": {
-                "tags": [
-                    "Favorites"
-                ],
-                "summary": "List favorites",
-                "description": "Get user's complete favorites list with details for each item",
-                "operationId": "listFavorites",
-                "responses": {
-                    "200": {
-                        "description": "Favorites list retrieved successfully",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "success": {
-                                            "type": "boolean",
-                                            "example": true
-                                        },
-                                        "message": {
-                                            "type": "string",
-                                            "example": "Favorites with details retrieved successfully"
-                                        },
-                                        "data": {
-                                            "type": "array",
-                                            "items": {
-                                                "$ref": "#/components/schemas/Favorite"
-                                            }
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorResponse"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "sanctum": []
-                    }
-                ]
-            },
             "post": {
                 "tags": [
                     "Favorites"
@@ -287,6 +236,59 @@
                     },
                     "404": {
                         "description": "Favorite not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/favorites/details": {
+            "get": {
+                "tags": [
+                    "Favorites"
+                ],
+                "summary": "List favorites",
+                "description": "Get user's complete favorites list with details for each item",
+                "operationId": "listFavorites",
+                "responses": {
+                    "200": {
+                        "description": "Favorites list retrieved successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Favorites with details retrieved successfully"
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Favorite"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -918,12 +920,12 @@
                 "tags": [
                     "Reviews"
                 ],
-                "summary": "Listar reseñas del usuario",
-                "description": "Obtiene todas las reseñas del usuario autenticado",
+                "summary": "List user reviews",
+                "description": "Gets all the reviews of the authenticated user",
                 "operationId": "listReviews",
                 "responses": {
                     "200": {
-                        "description": "Lista de reseñas recuperada exitosamente",
+                        "description": "Reviews list retrieved successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -933,7 +935,7 @@
                         }
                     },
                     "401": {
-                        "description": "No autenticado",
+                        "description": "Unauthorized",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -953,8 +955,8 @@
                 "tags": [
                     "Reviews"
                 ],
-                "summary": "Añadir una nueva reseña",
-                "description": "Crea una nueva reseña para una película o serie",
+                "summary": "Add a new review",
+                "description": "Creates a new review for a movie or series",
                 "operationId": "addReview",
                 "requestBody": {
                     "required": true,
@@ -968,7 +970,7 @@
                 },
                 "responses": {
                     "201": {
-                        "description": "Reseña creada exitosamente",
+                        "description": "Review created successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -978,7 +980,7 @@
                         }
                     },
                     "400": {
-                        "description": "La reseña ya existe o datos inválidos",
+                        "description": "Review already exists or invalid data",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -988,7 +990,7 @@
                         }
                     },
                     "401": {
-                        "description": "No autenticado",
+                        "description": "Unauthorized",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1010,14 +1012,14 @@
                 "tags": [
                     "Reviews"
                 ],
-                "summary": "Actualizar una reseña",
-                "description": "Actualiza una reseña existente",
+                "summary": "Update a review",
+                "description": "Updates an existing review",
                 "operationId": "updateReview",
                 "parameters": [
                     {
                         "name": "review",
                         "in": "path",
-                        "description": "ID de la reseña",
+                        "description": "Review ID",
                         "required": true,
                         "schema": {
                             "type": "integer"
@@ -1036,7 +1038,7 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "Reseña actualizada exitosamente",
+                        "description": "Review updated successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1046,7 +1048,7 @@
                         }
                     },
                     "403": {
-                        "description": "No autorizado para actualizar esta reseña",
+                        "description": "Unauthorized to update this review",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1056,7 +1058,7 @@
                         }
                     },
                     "401": {
-                        "description": "No autenticado",
+                        "description": "Unauthorized",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1076,14 +1078,14 @@
                 "tags": [
                     "Reviews"
                 ],
-                "summary": "Eliminar una reseña",
-                "description": "Elimina una reseña específica",
+                "summary": "Delete a review",
+                "description": "Deletes a specific review",
                 "operationId": "deleteReview",
                 "parameters": [
                     {
                         "name": "review",
                         "in": "path",
-                        "description": "ID de la reseña",
+                        "description": "Review ID",
                         "required": true,
                         "schema": {
                             "type": "integer"
@@ -1092,7 +1094,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Reseña eliminada exitosamente",
+                        "description": "Review deleted successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1112,7 +1114,7 @@
                         }
                     },
                     "403": {
-                        "description": "No autorizado para eliminar esta reseña",
+                        "description": "Unauthorized to delete this review",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1122,7 +1124,7 @@
                         }
                     },
                     "401": {
-                        "description": "No autenticado",
+                        "description": "Unauthorized",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1710,12 +1712,12 @@
                 "tags": [
                     "TMDB"
                 ],
-                "summary": "Obtener todas las categorías/géneros",
-                "description": "Retorna la lista completa de categorías/géneros disponibles en TMDB",
+                "summary": "Get all categories/genres",
+                "description": "Returns the complete list of categories/genres available in TMDB",
                 "operationId": "getAllCategories",
                 "responses": {
                     "200": {
-                        "description": "Lista de categorías recuperada exitosamente",
+                        "description": "Categories list retrieved successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1725,7 +1727,7 @@
                         }
                     },
                     "500": {
-                        "description": "Error del servidor",
+                        "description": "Server error",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1742,14 +1744,14 @@
                 "tags": [
                     "TMDB"
                 ],
-                "summary": "Obtener contenido trending",
-                "description": "Retorna una lista paginada de películas y series que son tendencia",
+                "summary": "Get trending content",
+                "description": "Returns a paginated list of movies and series that are trending",
                 "operationId": "getAllTrending",
                 "parameters": [
                     {
                         "name": "page",
                         "in": "query",
-                        "description": "Número de página (por defecto: 1)",
+                        "description": "Page number (default: 1)",
                         "required": false,
                         "schema": {
                             "type": "integer",
@@ -1759,7 +1761,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Lista de contenido trending recuperada exitosamente",
+                        "description": "Trending content list retrieved successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1822,7 +1824,7 @@
                         }
                     },
                     "500": {
-                        "description": "Error del servidor",
+                        "description": "Server error",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2078,90 +2080,6 @@
                         "sanctum": []
                     }
                 ]
-            }
-        },
-        "/api/forgot-password": {
-            "post": {
-                "tags": [
-                    "Users"
-                ],
-                "summary": "Request password reset",
-                "description": "Send a password reset link to the user's email",
-                "operationId": "forgotPassword",
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ForgotPasswordRequest"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Reset link sent successfully",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PasswordResetResponse"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Email not found or invalid",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationErrorResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/reset-password": {
-            "post": {
-                "tags": [
-                    "Users"
-                ],
-                "summary": "Confirm password reset",
-                "description": "Reset user's password using the received token",
-                "operationId": "resetPassword",
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ResetPasswordRequest"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Password reset successfully",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/PasswordResetResponse"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Invalid token or validation data",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationErrorResponse"
-                                }
-                            }
-                        }
-                    }
-                }
             }
         }
     },
@@ -3474,7 +3392,7 @@
         },
         {
             "name": "Reviews",
-            "description": "Operaciones relacionadas con reseñas de películas y series"
+            "description": "Operations related to movie and series reviews"
         },
         {
             "name": "Series",
@@ -3482,7 +3400,7 @@
         },
         {
             "name": "TMDB",
-            "description": "Operaciones generales de TMDB - categorías y contenido trending"
+            "description": "General TMDB operations - categories and trending content"
         },
         {
             "name": "Users",

--- a/pixela-frontend/src/features/trending/components/TrendingMediaCard.tsx
+++ b/pixela-frontend/src/features/trending/components/TrendingMediaCard.tsx
@@ -7,7 +7,6 @@ import { ActionButtons } from "@/shared/components/ActionButtons";
 import { MediaInfoDetails } from "./MediaInfoDetails";
 import { useRouter } from 'next/navigation';
 
-
 /**
  * Constantes para la configuración del componente
  */

--- a/pixela-frontend/src/shared/components/ActionButtons.tsx
+++ b/pixela-frontend/src/shared/components/ActionButtons.tsx
@@ -20,7 +20,7 @@ const STYLES = {
     },
     favorite: {
       active: 'p-3 rounded font-medium transition duration-300 flex items-center gap-2 shadow-lg bg-pixela-accent text-white hover:bg-pixela-accent/90',
-      inactive: 'p-3 rounded font-medium transition duration-300 flex items-center gap-2 shadow-lg'
+      inactive: 'p-3 rounded font-medium transition duration-300 flex items-center gap-2 shadow-lg border border-pixela-accent/40'
     }
   },
   icon: {


### PR DESCRIPTION
- Se tradujeron todos los comentarios de documentación en el backend del español al inglés para mantener coherencia y facilitar la colaboración internacional.
- Se eliminaron rutas no usadas en routes\api.php
- En el frontend, se añadió un borde rosa al botón de favoritos (FaBookmark) cuando no está activo, para unificar el estilo visual con el botón de comentarios (FaRegComments).