### PR TITLE
feat: añadir placeholder para posters faltantes en MediaPoster

### DIFF
--- a/pixela-frontend/src/features/media/components/hero/poster/MediaPoster.tsx
+++ b/pixela-frontend/src/features/media/components/hero/poster/MediaPoster.tsx
@@ -5,6 +5,12 @@ import clsx from 'clsx';
 import { useState, memo } from 'react';
 
 const STYLES = {
+  container: 'w-64 flex-shrink-0',
+  posterWrapper: 'relative group cursor-pointer',
+  imageContainer: 'relative w-full aspect-[2/3]',
+  image: 'rounded-lg shadow-2xl shadow-black/50 transition duration-300 group-hover:scale-105',
+  hoverOverlay: 'absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-lg flex items-center justify-center',
+  hoverText: 'text-white text-sm font-medium',
   placeholderContainer: 'absolute inset-0 bg-gradient-to-br from-gray-800 via-gray-900 to-black flex flex-col items-center justify-center p-4 text-center rounded-lg',
   placeholderEmoji: 'text-4xl mb-3 opacity-50',
   placeholderTitle: 'text-white text-sm font-medium leading-tight mb-2 line-clamp-3',
@@ -44,19 +50,19 @@ export const MediaPoster = ({ posterUrl, title, onClick, className, type = 'movi
   const [imageError, setImageError] = useState(false);
 
   return (
-    <div className={clsx("w-64 flex-shrink-0", className)}>
+    <div className={clsx(STYLES.container, className)}>
       <div 
-        className="relative group cursor-pointer"
+        className={STYLES.posterWrapper}
         onClick={onClick}
       >
-        <div className="relative w-full aspect-[2/3]">
+        <div className={STYLES.imageContainer}>
           {!posterUrl || posterUrl.trim() === '' || imageError ? (
             <PlaceholderPoster title={title} type={type} />
           ) : (
             <Image 
               src={posterUrl} 
               alt={title}
-              className="rounded-lg shadow-2xl shadow-black/50 transition duration-300 group-hover:scale-105"
+              className={STYLES.image}
               fill
               sizes="(max-width: 768px) 100vw, 256px"
               priority
@@ -65,8 +71,8 @@ export const MediaPoster = ({ posterUrl, title, onClick, className, type = 'movi
             />
           )}
         </div>
-        <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-lg flex items-center justify-center">
-          <span className="text-white text-sm font-medium">Ampliar</span>
+        <div className={STYLES.hoverOverlay}>
+          <span className={STYLES.hoverText}>Ampliar</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Descripción

Esta PR implementa un sistema de placeholder consistente para el componente `MediaPoster` cuando no hay imagen disponible, siguiendo el mismo patrón utilizado en `CategoriesContent`.

![Captura de pantalla 2025-06-05 190408](https://github.com/user-attachments/assets/ecc51df8-68ba-4ce6-95b3-439953d05f19)

### Cambios realizados

- **Nuevo componente PlaceholderPoster**: Componente reutilizable que muestra un placeholder elegante cuando no hay poster disponible
- **Manejo de errores de imagen**: Implementación de `useState` para detectar fallos de carga de imágenes
- **Distinción visual por tipo**: Uso de emojis diferentes para películas (🎬) y series (📺)
- **Nueva prop `type`**: Prop opcional para especificar si es película o serie
- **Objeto STYLES**: Consistencia con el patrón de estilos usado en el resto de la aplicación

### Funcionalidad

El placeholder se activa cuando:
- No hay `posterUrl` disponible
- La URL del poster está vacía
- Ocurre un error al cargar la imagen

### Consistencia visual

- Mismo diseño que el placeholder de `CategoriesContent`
- Mantiene la funcionalidad de hover y click del componente original
- Gradiente de fondo coherente con la identidad visual de la aplicación

---

**Nota**: Este cambio mejora la experiencia de usuario al proporcionar feedback visual claro cuando el contenido multimedia no tiene poster disponible.