### PR TITLE
feat: permitir a administradores gestionar reseñas de otros usuarios

### DIFF
--- a/pixela-backend/app/Http/Controllers/Api/ReviewController.php
+++ b/pixela-backend/app/Http/Controllers/Api/ReviewController.php
@@ -120,7 +120,7 @@ class ReviewController extends Controller
     {
         $user = $request->user();
 
-        if ($review->user_id !== $user->user_id) {
+        if ($review->user_id !== $user->user_id && !$user->is_admin) {
             return response()->json([
                 'success' => false,
                 'message' => 'You are not authorized to update this review.'
@@ -359,7 +359,7 @@ class ReviewController extends Controller
     {
         $user = $request->user();
 
-        if ($review->user_id !== $user->user_id) {
+        if ($review->user_id !== $user->user_id && !$user->is_admin) {
             return response()->json([
                 'success' => false,
                 'message' => 'You are not authorized to delete this review.'

--- a/pixela-frontend/src/features/media/components/review/ReviewCard.tsx
+++ b/pixela-frontend/src/features/media/components/review/ReviewCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { FiEdit2 } from 'react-icons/fi';
+import { FiEdit2, FiLoader } from 'react-icons/fi';
+import { FaTrash } from 'react-icons/fa';
 import Image from 'next/image';
 import { StarDisplay } from './StarDisplay';
 import { ReviewEditForm } from './ReviewEditForm';
@@ -24,10 +25,20 @@ const STYLES = {
       icon: "w-5 h-5"
     },
     name: "font-semibold text-white text-base group-hover:text-pixela-accent transition-colors duration-300",
-    date: "text-xs text-gray-400 font-mono"
+    date: "text-xs text-gray-400 font-mono min-w-20"
+  },
+  rightSection: {
+    container: "flex items-center gap-2 justify-end min-w-32"
   },
   edit: {
     button: "p-2 text-gray-400 hover:text-white transition-colors duration-200",
+    icon: "w-4 h-4"
+  },
+  actions: {
+    container: "flex items-center gap-1"
+  },
+  delete: {
+    button: "p-2 text-gray-400 hover:text-red-400 transition-colors duration-200",
     icon: "w-4 h-4"
   },
   content: {
@@ -47,7 +58,9 @@ export const ReviewCard = ({
   isEditing,
   onEditClick,
   onSave,
-  onCancel
+  onCancel,
+  onDelete,
+  isDeleting
 }: ReviewCardProps) => {
   const cardRef = useInteractiveBorder<HTMLDivElement>();
 
@@ -80,19 +93,36 @@ export const ReviewCard = ({
                 <StarDisplay value={Number(review.rating)} />
               </span>
             )}
-            {isUserReview && !isEditing && (
-              <button
-                onClick={() => onEditClick(review)}
-                className={STYLES.edit.button}
-                title="Editar reseña"
-              >
-                <FiEdit2 className={STYLES.edit.icon} />
-              </button>
-            )}
           </div>
-          <span className={STYLES.user.date}>
-            {review.created_at && new Date(review.created_at).toLocaleDateString()}
-          </span>
+          <div className={STYLES.rightSection.container}>
+            {isUserReview && !isEditing && (
+              <div className={STYLES.actions.container}>
+                <button
+                  onClick={() => onEditClick(review)}
+                  className={STYLES.edit.button}
+                  title="Editar reseña"
+                  disabled={isDeleting}
+                >
+                  <FiEdit2 className={STYLES.edit.icon} />
+                </button>
+                <button
+                  onClick={() => onDelete(review)}
+                  className={STYLES.delete.button}
+                  title="Eliminar reseña"
+                  disabled={isDeleting}
+                >
+                  {isDeleting ? (
+                    <FiLoader className={STYLES.delete.icon} />
+                  ) : (
+                    <FaTrash className={STYLES.delete.icon} />
+                  )}
+                </button>
+              </div>
+            )}
+            <span className={STYLES.user.date}>
+              {review.created_at && new Date(review.created_at).toLocaleDateString()}
+            </span>
+          </div>
         </div>
         {isEditing ? (
           <ReviewEditForm

--- a/pixela-frontend/src/features/media/types/reviews.ts
+++ b/pixela-frontend/src/features/media/types/reviews.ts
@@ -47,6 +47,8 @@ export interface ReviewSectionProps {
  * @property {() => void} onEditClick - Función que se ejecuta al hacer clic en editar
  * @property {() => void} onSave - Función que se ejecuta al guardar los cambios
  * @property {() => void} onCancel - Función que se ejecuta al cancelar la edición
+ * @property {() => void} onDelete - Función que se ejecuta al eliminar la reseña
+ * @property {boolean} isDeleting - Indica si se está eliminando la reseña
  */
 export interface ReviewCardProps {
   review: Review;
@@ -55,6 +57,8 @@ export interface ReviewCardProps {
   onEditClick: (review: Review) => void;
   onSave: (text: string, rating: number) => void;
   onCancel: () => void;
+  onDelete: (review: Review) => void;
+  isDeleting: boolean;
 }
 
 /**


### PR DESCRIPTION
# 🛡️ Gestión completa de reseñas para administradores

## 📋 Descripción

Esta PR implementa la funcionalidad completa para que los administradores puedan gestionar (editar y eliminar) las reseñas de otros usuarios, tanto desde el backend como desde la interfaz de usuario.

## 🎯 Problema

Anteriormente, los administradores no tenían la capacidad de moderar las reseñas de otros usuarios. Solo podían gestionar sus propias reseñas, lo que limitaba las funciones de administración de la plataforma.

## ✨ Cambios realizados

### Backend (`pixela-backend/`)
- **`ReviewController.php`**: Modificadas las validaciones en métodos `update()` y `delete()` para permitir acceso a administradores
  ```php
  // Antes: solo el autor podía editar/eliminar
  if ($review->user_id !== $user->user_id)
  
  // Ahora: autor O administrador pueden editar/eliminar  
  if ($review->user_id !== $user->user_id && !$user->is_admin)
  ```

### Frontend (`pixela-frontend/`)

#### **Tipos actualizados**
- **`reviews.ts`**: Agregadas props `onDelete` e `isDeleting` a `ReviewCardProps`

#### **Componentes mejorados**
- **`ReviewSection.tsx`**:
  - Agregado estado de administrador desde `useAuthStore`
  - Implementada función `handleDeleteReview()` 
  - Lógica de permisos: `canEditReview = isUserReview || isAdmin`

- **`ReviewCard.tsx`**:
  - Agregado botón de eliminar con icono `FaTrash` (consistente con ProfileReviews)
  - Reposicionados iconos de editar/eliminar a la derecha junto a la fecha
  - Implementada alineación consistente con `min-w-32` y `justify-end`
  - Agregados estados de loading para eliminación

## 🎨 Mejoras de UI

- **Iconos alineados**: Los controles de editar/eliminar ahora están perfectamente alineados entre todas las reseñas
- **Consistencia visual**: Uso del mismo icono `FaTrash` en toda la aplicación
- **Mejor UX**: Controles agrupados intuitivamente en la esquina superior derecha
- **Estados de loading**: Indicadores visuales durante operaciones de eliminación

## 🔐 Permisos

| Tipo de usuario | Editar propias | Eliminar propias | Editar otras | Eliminar otras |
|-----------------|----------------|------------------|--------------|----------------|
| Usuario normal  | ✅             | ✅               | ❌           | ❌             |
| Administrador   | ✅             | ✅               | ✅           | ✅             |

## 🧪 Testing

- [ ] Verificar que usuarios normales solo ven controles en sus reseñas
- [ ] Verificar que administradores ven controles en todas las reseñas  
- [ ] Probar edición de reseñas ajenas como administrador
- [ ] Probar eliminación de reseñas ajenas como administrador
- [ ] Verificar alineación consistente de iconos con fechas de diferentes longitudes
- [ ] Comprobar estados de loading durante eliminación

## 📸 Vista previa

**Antes**: Solo el autor veía los controles de edición

**Después**: Los administradores ven controles en todas las reseñas con iconos perfectamente alineados
# 🛡️ Gestión completa de reseñas para administradores

## 📋 Descripción

Esta PR implementa la funcionalidad completa para que los administradores puedan gestionar (editar y eliminar) las reseñas de otros usuarios, tanto desde el backend como desde la interfaz de usuario.

## 🎯 Problema

Anteriormente, los administradores no tenían la capacidad de moderar las reseñas de otros usuarios. Solo podían gestionar sus propias reseñas, lo que limitaba las funciones de administración de la plataforma.

## ✨ Cambios realizados

### Backend (`pixela-backend/`)
- **`ReviewController.php`**: Modificadas las validaciones en métodos `update()` y `delete()` para permitir acceso a administradores
  ```php
  // Antes: solo el autor podía editar/eliminar
  if ($review->user_id !== $user->user_id)
  
  // Ahora: autor O administrador pueden editar/eliminar  
  if ($review->user_id !== $user->user_id && !$user->is_admin)
  ```

### Frontend (`pixela-frontend/`)

#### **Tipos actualizados**
- **`reviews.ts`**: Agregadas props `onDelete` e `isDeleting` a `ReviewCardProps`

#### **Componentes mejorados**
- **`ReviewSection.tsx`**:
  - Agregado estado de administrador desde `useAuthStore`
  - Implementada función `handleDeleteReview()` 
  - Lógica de permisos: `canEditReview = isUserReview || isAdmin`

- **`ReviewCard.tsx`**:
  - Agregado botón de eliminar con icono `FaTrash` (consistente con ProfileReviews)
  - Reposicionados iconos de editar/eliminar a la derecha junto a la fecha
  - Implementada alineación consistente con `min-w-32` y `justify-end`
  - Agregados estados de loading para eliminación

## 🎨 Mejoras de UI

- **Iconos alineados**: Los controles de editar/eliminar ahora están perfectamente alineados entre todas las reseñas
- **Consistencia visual**: Uso del mismo icono `FaTrash` en toda la aplicación
- **Mejor UX**: Controles agrupados intuitivamente en la esquina superior derecha
- **Estados de loading**: Indicadores visuales durante operaciones de eliminación

## 🔐 Permisos

| Tipo de usuario | Editar propias | Eliminar propias | Editar otras | Eliminar otras |
|-----------------|----------------|------------------|--------------|----------------|
| Usuario normal  | ✅             | ✅               | ❌           | ❌             |
| Administrador   | ✅             | ✅               | ✅           | ✅             |

## 🧪 Testing

- [ ] Verificar que usuarios normales solo ven controles en sus reseñas
- [ ] Verificar que administradores ven controles en todas las reseñas  
- [ ] Probar edición de reseñas ajenas como administrador
- [ ] Probar eliminación de reseñas ajenas como administrador
- [ ] Verificar alineación consistente de iconos con fechas de diferentes longitudes
- [ ] Comprobar estados de loading durante eliminación

## 📸 Vista previa

**Antes**: Solo el autor veía los controles de edición
![image](https://github.com/user-attachments/assets/da393707-3880-4fc6-a026-44a7139d7b96)

**Después**: Los administradores ven controles en todas las reseñas con iconos perfectamente alineados
![Captura de pantalla 2025-06-15 124550](https://github.com/user-attachments/assets/82c2d6ae-39e2-4528-bdf4-d91f960d4f29)

## 🚀 Impacto

Esta implementación permite a los administradores moderar efectivamente el contenido de reseñas en la plataforma, mejorando la capacidad de gestión y mantenimiento de la calidad del contenido.